### PR TITLE
Добавлена регистронезависимость идентификаторов

### DIFF
--- a/src/main/java/ru/rtf/Deck.java
+++ b/src/main/java/ru/rtf/Deck.java
@@ -15,6 +15,7 @@ public class Deck {
     private final String name;
     /**
      * Карты колоды, где ключ - термин карты, значение - сама карта
+     * Термин карты хранится в нижнем регистре для обеспечения регистронезависимости при получении карты
      */
     private final Map<String, Card> cards;
 
@@ -85,7 +86,7 @@ public class Deck {
      */
     public void addCard(String term, String definition) {
         validateUnique(term);
-        cards.put(term, new Card(term, definition));
+        cards.put(term.toLowerCase(), new Card(term, definition));
     }
 
     /**
@@ -95,8 +96,9 @@ public class Deck {
      * @throws IllegalArgumentException Карта с таким термином существует в колоде
      */
     public void addCard(Card card) {
-        validateUnique(card.getTerm());
-        cards.put(card.getTerm(), card);
+        String term = card.getTerm();
+        validateUnique(term);
+        cards.put(term.toLowerCase(), card);
     }
 
     /**
@@ -112,9 +114,9 @@ public class Deck {
         validateExists(oldTerm);
         validateUnique(newTerm);
 
-        Card oldCard = cards.get(oldTerm);
-        cards.remove(oldTerm);
-        cards.put(newTerm, oldCard.changeTerm(newTerm));
+        Card oldCard = cards.get(oldTerm.toLowerCase());
+        cards.remove(oldTerm.toLowerCase());
+        cards.put(newTerm.toLowerCase(), oldCard.changeTerm(newTerm));
     }
 
     /**
@@ -126,7 +128,7 @@ public class Deck {
      */
     public void updateCardDefinition(String term, String newDefinition) {
         validateExists(term);
-        cards.get(term).changeDefinition(newDefinition);
+        cards.get(term.toLowerCase()).changeDefinition(newDefinition);
     }
 
     /**
@@ -137,7 +139,7 @@ public class Deck {
      */
     public Card getCard(String term) {
         validateExists(term);
-        return cards.get(term);
+        return cards.get(term.toLowerCase());
     }
 
     /**
@@ -157,7 +159,7 @@ public class Deck {
      */
     public void removeCard(String term) {
         validateExists(term);
-        cards.remove(term);
+        cards.remove(term.toLowerCase());
     }
 
     /**
@@ -198,7 +200,7 @@ public class Deck {
      * @throws IllegalArgumentException Карта с таким термином существует в колоде
      */
     private void validateUnique(String term) {
-        if (cards.containsKey(term))
+        if (cards.containsKey(term.toLowerCase()))
             throw new IllegalArgumentException("Карта с термином " + term + " существует в колоде");
 
     }
@@ -210,7 +212,7 @@ public class Deck {
      * @throws NoSuchElementException Карта с таким термином не существует в колоде
      */
     private void validateExists(String term) {
-        if (!cards.containsKey(term))
+        if (!cards.containsKey(term.toLowerCase()))
             throw new NoSuchElementException("Карта с термином " + term + " не существует в колоде");
     }
 }

--- a/src/main/java/ru/rtf/DeckManager.java
+++ b/src/main/java/ru/rtf/DeckManager.java
@@ -7,6 +7,7 @@ import java.util.NoSuchElementException;
 
 /**
  * Менеджер управления колодами пользователя
+ * <p>Для работы с картами колоды следует получить экземпляр колоды через метод {@link DeckManager#getDeck}</p>
  *
  * @author k4noise
  * @since 21.10.2024
@@ -14,6 +15,7 @@ import java.util.NoSuchElementException;
 public class DeckManager {
     /**
      * Колоды менеджера, где ключ - имя колоды, значение - сама колода
+     * Имя колоды хранится в нижнем регистре для обеспечения регистронезависимости при получении колоды
      */
     private final Map<String, Deck> decks;
 
@@ -33,7 +35,7 @@ public class DeckManager {
      */
     public void addDeck(String name) {
         validateUnique(name);
-        decks.put(name, new Deck(name));
+        decks.put(name.toLowerCase(), new Deck(name));
     }
 
     /**
@@ -44,7 +46,7 @@ public class DeckManager {
      */
     public Deck getDeck(String name) {
         validateExists(name);
-        return decks.get(name);
+        return decks.get(name.toLowerCase());
     }
 
     /**
@@ -60,8 +62,8 @@ public class DeckManager {
         validateExists(oldName);
         validateUnique(newName);
 
-        Deck deck = decks.remove(oldName);
-        decks.put(newName, deck.updateName(newName));
+        Deck deck = decks.remove(oldName.toLowerCase());
+        decks.put(newName.toLowerCase(), deck.updateName(newName));
     }
 
     /**
@@ -72,7 +74,7 @@ public class DeckManager {
      */
     public void removeDeck(String name) {
         validateExists(name);
-        decks.remove(name);
+        decks.remove(name.toLowerCase());
     }
 
     /**
@@ -91,7 +93,7 @@ public class DeckManager {
      * @throws IllegalArgumentException Колода с таким именем существует в менеджере
      */
     private void validateUnique(String name) {
-        if (decks.containsKey(name))
+        if (decks.containsKey(name.toLowerCase()))
             throw new IllegalArgumentException("Колода с именем " + name + " существует в менеджере");
     }
 
@@ -102,7 +104,7 @@ public class DeckManager {
      * @throws NoSuchElementException Колода с таким именем не существует в менеджере
      */
     private void validateExists(String name) {
-        if (!decks.containsKey(name))
+        if (!decks.containsKey(name.toLowerCase()))
             throw new NoSuchElementException("Колода с именем " + name + " не существует в менеджере");
     }
 }

--- a/src/test/java/ru/rtf/DeckManagerTest.java
+++ b/src/test/java/ru/rtf/DeckManagerTest.java
@@ -63,14 +63,12 @@ class DeckManagerTest {
     @Test
     @DisplayName("Проверка регистронезависимости при добавлении колоды с существующим именем")
     void testAddDeckWithDuplicateNameIgnoreCase() {
-        String deckName = "Deck";
-        deckManager.addDeck(deckName);
-
-        Assertions.assertThrows(
+        IllegalArgumentException exception = Assertions.assertThrows(
                 IllegalArgumentException.class,
-                () -> deckManager.addDeck(deckName.toUpperCase()),
+                () -> deckManager.addDeck("DECK"),
                 "Колода с существующим именем не может быть добавлена"
         );
+        Assertions.assertEquals("Колода с именем DECK существует в менеджере", exception.getMessage());
     }
 
     /**
@@ -106,9 +104,7 @@ class DeckManagerTest {
     @Test
     @DisplayName("Проверка регистронезависимости при удалении созданной колоды")
     void testRemoveDeckIgnoreCase() {
-        String deckName = "Deck";
-        deckManager.addDeck(deckName);
-        deckManager.removeDeck(deckName.toUpperCase());
+        deckManager.removeDeck("DECK");
         Collection<Deck> decks = deckManager.getDecks();
 
         Assertions.assertTrue(decks.isEmpty(), "Не должно быть сохраненных колод в менеджере");
@@ -148,12 +144,9 @@ class DeckManagerTest {
     @Test
     @DisplayName("Проверка регистронезависимости получения созданной колоды")
     void testGetDeckIgnoreCase() {
-        String deckName = "Deck";
-        deckManager.addDeck(deckName);
-
-        Deck deck = deckManager.getDeck(deckName.toUpperCase());
+        Deck deck = deckManager.getDeck("DECK");
         Assertions.assertEquals(
-                deckName,
+                "Deck",
                 deck.getName(),
                 "Колода должна иметь имя, указанное при создании"
         );
@@ -237,18 +230,9 @@ class DeckManagerTest {
     @Test
     @DisplayName("Проверка регистронезависимости при изменении имени у созданной колоды")
     void testUpdateNameDeckIgnoreCase() {
-        String deckName = "Deck";
-        deckManager.addDeck(deckName);
-        String newDeckName = deckName + '1';
+        deckManager.updateDeckName("DECK", "Deck1");
+        Deck deck = deckManager.getDeck("Deck1");
 
-        deckManager.updateDeckName(deckName.toUpperCase(), newDeckName);
-        Deck deck = deckManager.getDeck(newDeckName);
-
-        Assertions.assertThrows(NoSuchElementException.class,
-                () -> deckManager.getDeck(deckName),
-                "Невозможно получить колоду по старому имени"
-        );
-        Assertions.assertNotEquals(deckName, deck.getName(), "Колода не должна иметь старое имя");
-        Assertions.assertEquals(newDeckName, deck.getName(), "Колода должна иметь новое имя");
+        Assertions.assertEquals("Deck1", deck.getName(), "Колода должна иметь новое имя");
     }
 }

--- a/src/test/java/ru/rtf/DeckManagerTest.java
+++ b/src/test/java/ru/rtf/DeckManagerTest.java
@@ -66,6 +66,22 @@ class DeckManagerTest {
     }
 
     /**
+     * Тестирование регистронезависимости метода {@link DeckManager#addDeck}
+     */
+    @Test
+    @DisplayName("Проверка регистронезависимости при добавлении колоды с существующим именем")
+    void testAddDeckWithDuplicateNameIgnoreCase() {
+        String deckName = "Deck";
+        deckManager.addDeck(deckName);
+
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> deckManager.addDeck(deckName.toUpperCase()),
+                "Колода с существующим именем не может быть добавлена"
+        );
+    }
+
+    /**
      * Тестирование метода {@link DeckManager#removeDeck} на корректных данных
      */
     @Test
@@ -98,7 +114,21 @@ class DeckManagerTest {
     }
 
     /**
-     * Тестирование метода {@link DeckManager#getDeck}
+     * Тестирование регистронезависимости метода {@link DeckManager#removeDeck}
+     */
+    @Test
+    @DisplayName("Проверка регистронезависимости при удалении созданной колоды")
+    void testRemoveDeckIgnoreCase() {
+        String deckName = "Deck";
+        deckManager.addDeck(deckName);
+        deckManager.removeDeck(deckName.toUpperCase());
+        Collection<Deck> decks = deckManager.getDecks();
+
+        Assertions.assertTrue(decks.isEmpty(), "Не должно быть сохраненных колод в менеджере");
+    }
+
+    /**
+     * Тестирование метода {@link DeckManager#getDeck} на уникальных данных
      */
     @Test
     @DisplayName("Получение созданной колоды")
@@ -115,7 +145,7 @@ class DeckManagerTest {
     }
 
     /**
-     * Тестирование метода {@link DeckManager#getDeck}
+     * Тестирование метода {@link DeckManager#getDeck} на отсутствующих данных
      */
     @Test
     @DisplayName("Получение несуществующей колоды")
@@ -128,6 +158,23 @@ class DeckManagerTest {
                 NoSuchElementException.class,
                 () -> deckManager.getDeck(wrongDeckName),
                 "Невозможно получить не сохраненную в менеджере колод колоду"
+        );
+    }
+
+    /**
+     * Тестирование регистронезависимости метода {@link DeckManager#getDeck}
+     */
+    @Test
+    @DisplayName("Проверка регистронезависимости получения созданной колоды")
+    void testGetDeckIgnoreCase() {
+        String deckName = "Deck";
+        deckManager.addDeck(deckName);
+
+        Deck deck = deckManager.getDeck(deckName.toUpperCase());
+        Assertions.assertEquals(
+                deckName,
+                deck.getName(),
+                "Колода должна иметь имя, указанное при создании"
         );
     }
 
@@ -163,8 +210,8 @@ class DeckManagerTest {
         String deckName = "Deck";
         deckManager.addDeck(deckName);
         String newDeckName = deckName + '1';
-        deckManager.updateDeckName(deckName, newDeckName);
 
+        deckManager.updateDeckName(deckName, newDeckName);
         Deck deck = deckManager.getDeck(newDeckName);
 
         Assertions.assertThrows(NoSuchElementException.class,
@@ -208,5 +255,26 @@ class DeckManagerTest {
                 () -> deckManager.updateDeckName(deckName, newDeckName),
                 "Невозможно изменить имя, так как оно уже используется другой колодой"
         );
+    }
+
+    /**
+     * Тестирование регистронезависимости метода {@link DeckManager#updateDeckName}
+     */
+    @Test
+    @DisplayName("Проверка регистронезависимости при изменении имени у созданной колоды")
+    void testUpdateNameDeckIgnoreCase() {
+        String deckName = "Deck";
+        deckManager.addDeck(deckName);
+        String newDeckName = deckName + '1';
+
+        deckManager.updateDeckName(deckName.toUpperCase(), newDeckName);
+        Deck deck = deckManager.getDeck(newDeckName);
+
+        Assertions.assertThrows(NoSuchElementException.class,
+                () -> deckManager.getDeck(deckName),
+                "Невозможно получить колоду по старому имени"
+        );
+        Assertions.assertNotEquals(deckName, deck.getName(), "Колода не должна иметь старое имя");
+        Assertions.assertEquals(newDeckName, deck.getName(), "Колода должна иметь новое имя");
     }
 }

--- a/src/test/java/ru/rtf/DeckTest.java
+++ b/src/test/java/ru/rtf/DeckTest.java
@@ -132,18 +132,14 @@ class DeckTest {
     @Test
     @DisplayName("Проверка регистронезависимости при добавлении карты в колоду")
     void testCorrectAddCardIgnoreCase() {
-        String deckName = "Deck";
-        Deck deck = new Deck(deckName);
-        String term = "term", definition = "definition";
-        deck.addCard(term, definition);
-        int deckCardsCount = deck.getCardsCount();
+        deck.addCard("term", "definition");
 
-        Assertions.assertThrows(
+        IllegalArgumentException exception = Assertions.assertThrows(
                 IllegalArgumentException.class,
-                () -> deck.addCard(term.toUpperCase(), definition),
+                () -> deck.addCard("TERM", "definition"),
                 "Добавление карты с существующим термином невозможно"
         );
-        Assertions.assertEquals(deckCardsCount, deck.getCardsCount(), "Количество карт не должно измениться");
+        Assertions.assertEquals("Карта с термином TERM существует в колоде", exception.getMessage());
     }
 
     /**
@@ -182,19 +178,15 @@ class DeckTest {
     @Test
     @DisplayName("Проверка регистронезависимости при добавлении экземпляра карты в колоду")
     void testAddCardInstanceIgnoreCase() {
-        String deckName = "Deck";
-        Deck deck = new Deck(deckName);
-        String term = "term", definition = "definition";
-        Card card = new Card(term.toUpperCase(), definition);
+        Card card = new Card("TERM", "definition");
         deck.addCard(card);
-        int deckCardsCount = deck.getCardsCount();
 
-        Assertions.assertThrows(
+        IllegalArgumentException exception = Assertions.assertThrows(
                 IllegalArgumentException.class,
                 () -> deck.addCard(card),
                 "Повторное добавление карты запрещено"
         );
-        Assertions.assertEquals(deckCardsCount, deck.getCardsCount(), "Количество карт не должно измениться");
+        Assertions.assertEquals("Карта с термином TERM существует в колоде", exception.getMessage());
     }
 
     /**
@@ -255,24 +247,11 @@ class DeckTest {
     @Test
     @DisplayName("Проверка регистронезависимости при изменении термина у карты")
     void testUpdateCardTermIgnoreCase() {
-        String deckName = "Deck";
-        Deck deck = new Deck(deckName);
-        String term = "term", definition = "definition";
-        Card card = new Card(term, definition);
+        Card card = new Card("term", "definition");
         deck.addCard(card);
-        int deckCardsCount = deck.getCardsCount();
+        deck.updateCardTerm("TERM", "newTerm");
 
-        String newTerm = term + '1';
-        deck.updateCardTerm(term.toUpperCase(), newTerm);
-
-        Assertions.assertThrows(
-                NoSuchElementException.class,
-                () -> deck.getCard(term),
-                "Старый экземпляр карты не должен существовать"
-        );
-        Assertions.assertNotEquals(card, deck.getCard(newTerm.toUpperCase()), "Экземпляр карты должен измениться");
-        Assertions.assertEquals(definition, deck.getCard(newTerm).getDefinition(), "Определение должно сохраниться");
-        Assertions.assertEquals(deckCardsCount, deck.getCardsCount(), "Количество карт в колоде не должно измениться");
+        Assertions.assertEquals("definition", deck.getCard("newTerm").getDefinition(), "Определение должно сохраниться");
     }
 
     /**
@@ -311,18 +290,11 @@ class DeckTest {
     @Test
     @DisplayName("Проверка регистронезависимости при изменении определения у карты")
     void testUpdateCardDefinitionIgnoreCase() {
-        String deckName = "Deck";
-        Deck deck = new Deck(deckName);
-        String term = "term", definition = "definition";
-        Card card = new Card(term, definition);
+        Card card = new Card("term", "definition");
         deck.addCard(card);
+        deck.updateCardDefinition("TERM", "newDefinition");
 
-        String newDefinition = definition + '1';
-        deck.updateCardDefinition(term.toUpperCase(), newDefinition);
-        Card updatedCard = deck.getCard(term);
-
-        Assertions.assertEquals(card, updatedCard, "Экземпляр карты не должен измениться");
-        Assertions.assertEquals(card.getDefinition(), updatedCard.getDefinition(), "Определение должно было измениться");
+        Assertions.assertEquals("newDefinition", deck.getCard("term").getDefinition(), "Определение должно было измениться");
     }
 
     /**
@@ -362,14 +334,10 @@ class DeckTest {
     @Test
     @DisplayName("Проверка регистронезависимости при получении карты")
     void testGetCardIgnoreCase() {
-        String deckName = "Deck";
-        Deck deck = new Deck(deckName);
-        String term = "term", definition = "definition";
-        Card card = new Card(term, definition);
+        Card card = new Card("term", "definition");
         deck.addCard(card);
 
-        Card actualCard = deck.getCard(term.toUpperCase());
-
+        Card actualCard = deck.getCard("TERM");
         Assertions.assertEquals(card, actualCard, "Карты должны быть одинаковыми");
     }
 
@@ -429,17 +397,15 @@ class DeckTest {
     @Test
     @DisplayName("Проверка регистронезависимости при удалении карты")
     void testRemoveCardIgnoreCase() {
-        String deckName = "Deck";
-        Deck deck = new Deck(deckName);
-        String term = "term", definition = "definition";
-        deck.addCard(term, definition);
+        deck.addCard("term", "definition");
 
-        deck.removeCard(term.toUpperCase());
-        Assertions.assertThrows(
+        deck.removeCard("TERM");
+        NoSuchElementException exception = Assertions.assertThrows(
                 NoSuchElementException.class,
-                () -> deck.getCard(term),
+                () -> deck.getCard("term"),
                 "Удаленная карта не должна существовать в колоде после ее удаления"
         );
+        Assertions.assertEquals("Карта с термином term не существует в колоде", exception.getMessage());
     }
 
     /**

--- a/src/test/java/ru/rtf/DeckTest.java
+++ b/src/test/java/ru/rtf/DeckTest.java
@@ -139,6 +139,26 @@ class DeckTest {
     }
 
     /**
+     * Тестирование регистронезависимости метода {@link Deck#addCard}
+     */
+    @Test
+    @DisplayName("Проверка регистронезависимости при добавлении карты в колоду")
+    void testCorrectAddCardIgnoreCase() {
+        String deckName = "Deck";
+        Deck deck = new Deck(deckName);
+        String term = "term", definition = "definition";
+        deck.addCard(term, definition);
+        int deckCardsCount = deck.getCardsCount();
+
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> deck.addCard(term.toUpperCase(), definition),
+                "Добавление карты с существующим термином невозможно"
+        );
+        Assertions.assertEquals(deckCardsCount, deck.getCardsCount(), "Количество карт не должно измениться");
+    }
+
+    /**
      * Тестирование перегрузки метода {@link Deck#addCard} с корректными данными
      */
     @Test
@@ -165,6 +185,27 @@ class DeckTest {
         Deck deck = new Deck(deckName);
         String term = "term", definition = "definition";
         Card card = new Card(term, definition);
+        deck.addCard(card);
+        int deckCardsCount = deck.getCardsCount();
+
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> deck.addCard(card),
+                "Повторное добавление карты запрещено"
+        );
+        Assertions.assertEquals(deckCardsCount, deck.getCardsCount(), "Количество карт не должно измениться");
+    }
+
+    /**
+     * Тестирование регистронезависимости перегрузки метода {@link Deck#addCard}
+     */
+    @Test
+    @DisplayName("Проверка регистронезависимости при добавлении экземпляра карты в колоду")
+    void testAddCardInstanceIgnoreCase() {
+        String deckName = "Deck";
+        Deck deck = new Deck(deckName);
+        String term = "term", definition = "definition";
+        Card card = new Card(term.toUpperCase(), definition);
         deck.addCard(card);
         int deckCardsCount = deck.getCardsCount();
 
@@ -250,6 +291,32 @@ class DeckTest {
     }
 
     /**
+     * Тестирование регистронезависимости метода {@link Deck#updateCardTerm}
+     */
+    @Test
+    @DisplayName("Проверка регистронезависимости при изменении термина у карты")
+    void testUpdateCardTermIgnoreCase() {
+        String deckName = "Deck";
+        Deck deck = new Deck(deckName);
+        String term = "term", definition = "definition";
+        Card card = new Card(term, definition);
+        deck.addCard(card);
+        int deckCardsCount = deck.getCardsCount();
+
+        String newTerm = term + '1';
+        deck.updateCardTerm(term.toUpperCase(), newTerm);
+
+        Assertions.assertThrows(
+                NoSuchElementException.class,
+                () -> deck.getCard(term),
+                "Старый экземпляр карты не должен существовать"
+        );
+        Assertions.assertNotEquals(card, deck.getCard(newTerm.toUpperCase()), "Экземпляр карты должен измениться");
+        Assertions.assertEquals(definition, deck.getCard(newTerm).getDefinition(), "Определение должно сохраниться");
+        Assertions.assertEquals(deckCardsCount, deck.getCardsCount(), "Количество карт в колоде не должно измениться");
+    }
+
+    /**
      * Тестирование метода {@link Deck#updateCardDefinition} на корректных данных
      */
     @Test
@@ -289,6 +356,26 @@ class DeckTest {
     }
 
     /**
+     * Тестирование регистронезависимости метода {@link Deck#updateCardDefinition}
+     */
+    @Test
+    @DisplayName("Проверка регистронезависимости при изменении определения у карты")
+    void testUpdateCardDefinitionIgnoreCase() {
+        String deckName = "Deck";
+        Deck deck = new Deck(deckName);
+        String term = "term", definition = "definition";
+        Card card = new Card(term, definition);
+        deck.addCard(card);
+
+        String newDefinition = definition + '1';
+        deck.updateCardDefinition(term.toUpperCase(), newDefinition);
+        Card updatedCard = deck.getCard(term);
+
+        Assertions.assertEquals(card, updatedCard, "Экземпляр карты не должен измениться");
+        Assertions.assertEquals(card.getDefinition(), updatedCard.getDefinition(), "Определение должно было измениться");
+    }
+
+    /**
      * Тестирование метода {@link Deck#getCard} на существующих данных
      */
     @Test
@@ -323,6 +410,23 @@ class DeckTest {
     }
 
     /**
+     * Тестирование регистронезависимости метода {@link Deck#getCard}
+     */
+    @Test
+    @DisplayName("Проверка регистронезависимости при получении карты")
+    void testGetCardIgnoreCase() {
+        String deckName = "Deck";
+        Deck deck = new Deck(deckName);
+        String term = "term", definition = "definition";
+        Card card = new Card(term, definition);
+        deck.addCard(card);
+
+        Card actualCard = deck.getCard(term.toUpperCase());
+
+        Assertions.assertEquals(card, actualCard, "Карты должны быть одинаковыми");
+    }
+
+    /**
      * Тестирование метода {@link Deck#getCards}
      */
     @Test
@@ -339,31 +443,6 @@ class DeckTest {
 
         Assertions.assertEquals(1, deck.getCards().size(), "Должна быть добавлена карта");
         Assertions.assertEquals(card, deck.getCards().iterator().next(), "Карта должна находиться в колоде");
-    }
-
-    /**
-     * Тестирование метода {@link Deck#hashCode}
-     */
-    @Test
-    @DisplayName("Сравнение хешей колод")
-    void testHashCode() {
-        String deckName = "Deck";
-        String anotherDeckName = deckName + '1';
-        Deck deck1 = new Deck(deckName);
-        Deck deck2 = new Deck(deckName);
-        Deck deck3 = new Deck(anotherDeckName);
-
-        Assertions.assertEquals(
-                deck1.hashCode(),
-                deck2.hashCode(),
-                "Хеши колод с одинаковым именем должны быть равны"
-        );
-
-        Assertions.assertNotEquals(
-                deck2.hashCode(),
-                deck3.hashCode(),
-                "Хеши колод с разными именами должны быть разными"
-        );
     }
 
     /**
@@ -405,6 +484,25 @@ class DeckTest {
     }
 
     /**
+     * Тестирование регистронезависимости метода {@link Deck#removeCard}
+     */
+    @Test
+    @DisplayName("Проверка регистронезависимости при удалении карты")
+    void testRemoveCardIgnoreCase() {
+        String deckName = "Deck";
+        Deck deck = new Deck(deckName);
+        String term = "term", definition = "definition";
+        deck.addCard(term, definition);
+
+        deck.removeCard(term.toUpperCase());
+        Assertions.assertThrows(
+                NoSuchElementException.class,
+                () -> deck.getCard(term),
+                "Удаленная карта не должна существовать в колоде после ее удаления"
+        );
+    }
+
+    /**
      * Тестирование метода {@link Deck#getCardsDescription()}
      */
     @Test
@@ -427,6 +525,31 @@ class DeckTest {
                 sb.toString(),
                 deck.getCardsDescription(),
                 "Должно быть описание всех карт колоды без изменения их порядка"
+        );
+    }
+
+    /**
+     * Тестирование метода {@link Deck#hashCode}
+     */
+    @Test
+    @DisplayName("Сравнение хешей колод")
+    void testHashCode() {
+        String deckName = "Deck";
+        String anotherDeckName = deckName + '1';
+        Deck deck1 = new Deck(deckName);
+        Deck deck2 = new Deck(deckName);
+        Deck deck3 = new Deck(anotherDeckName);
+
+        Assertions.assertEquals(
+                deck1.hashCode(),
+                deck2.hashCode(),
+                "Хеши колод с одинаковым именем должны быть равны"
+        );
+
+        Assertions.assertNotEquals(
+                deck2.hashCode(),
+                deck3.hashCode(),
+                "Хеши колод с разными именами должны быть разными"
         );
     }
 

--- a/src/test/java/ru/rtf/DeckTest.java
+++ b/src/test/java/ru/rtf/DeckTest.java
@@ -298,23 +298,6 @@ class DeckTest {
     }
 
     /**
-     * Тестирование метода {@link Deck#getCard} на существующих данных
-     */
-    @Test
-    @DisplayName("Получение карты")
-    void testGetCard() {
-        String deckName = "Deck";
-        Deck deck = new Deck(deckName);
-        String term = "term", definition = "definition";
-        Card card = new Card(term, definition);
-        deck.addCard(card);
-
-        Card actualCard = deck.getCard(term);
-
-        Assertions.assertEquals(card, actualCard, "Карты должны быть одинаковыми");
-    }
-
-    /**
      * Тестирование метода {@link Deck#getCard} на отсутствующих данных
      */
     @Test

--- a/src/test/java/ru/rtf/DeckTest.java
+++ b/src/test/java/ru/rtf/DeckTest.java
@@ -418,14 +418,11 @@ class DeckTest {
     @Test
     @DisplayName("Сравнение хешей колод")
     void testHashCode() {
-        String deckName = "Deck";
-        String anotherDeckName = deckName + '1';
-        Deck deck1 = new Deck(deckName);
-        Deck deck2 = new Deck(deckName);
-        Deck deck3 = new Deck(anotherDeckName);
+        Deck deck2 = new Deck("Deck");
+        Deck deck3 = new Deck("anotherDeckName");
 
         Assertions.assertEquals(
-                deck1.hashCode(),
+                deck.hashCode(),
                 deck2.hashCode(),
                 "Хеши колод с одинаковым именем должны быть равны"
         );


### PR DESCRIPTION
Теперь пользователь может игнорировать регистр при работе с существующей картой или колодой.
Например, при создании колоды ООП с картой SOLID будет корректным обращение к колоде ОоП с картой Solid.
Но при запросе имени карты/колоды будет возвращено имя с оригинальным регистром, для нашего примера: для колоды - ООП, для карты - SOLID.

Изменения могут быть смерджены только тогда, когда задача будет пересогласована.

Тесты - 96/96
![image](https://github.com/user-attachments/assets/4cb5b875-1b08-4707-9e1a-d8b1904f3e39)
